### PR TITLE
Add MySQL RDS DB to the infra

### DIFF
--- a/infrastructure/env-dev/data/init.bat
+++ b/infrastructure/env-dev/data/init.bat
@@ -1,0 +1,5 @@
+terraform remote config -backend=s3 ^
+ -backend-config="bucket=terraform-states-iac-experiment" ^
+ -backend-config="key=dev/data.tfstate" ^
+ -backend-config="region=us-east-1" ^
+ -backend-config="encrypt=true"

--- a/infrastructure/env-dev/data/init.sh
+++ b/infrastructure/env-dev/data/init.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+terraform remote config -backend=s3 \
+ -backend-config="bucket=terraform-states-iac-experiment" \
+ -backend-config="key=dev/data.tfstate" \
+ -backend-config="region=us-east-1" \
+ -backend-config="encrypt=true"

--- a/infrastructure/env-dev/data/main.tf
+++ b/infrastructure/env-dev/data/main.tf
@@ -1,0 +1,22 @@
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config {
+    bucket = "terraform-states-iac-experiment"
+    key    = "dev/network.tfstate"
+    region = "us-east-1"
+  }
+}
+
+provider "aws" {
+  region = "${var.region}"
+}
+
+module "data" {
+  source = "../../modules/data"
+
+  env         = "dev"
+  subnets_id  = ["${data.terraform_remote_state.network.back_subnets}"]
+  cidr_blocks = ["${data.terraform_remote_state.network.back_subnets_cidr}"]
+  vpc_id      = "${data.terraform_remote_state.network.vpc_id}"
+}

--- a/infrastructure/env-dev/data/outputs.tf
+++ b/infrastructure/env-dev/data/outputs.tf
@@ -6,6 +6,6 @@ output "rds_endpoint" {
   value = "${module.data.rds_endpoint}"
 }
 
-output "rds_sg_id" {
-  value = "${module.data.rds_sg_id}"
+output "sg_rds_id" {
+  value = "${module.data.sg_rds_id}"
 }

--- a/infrastructure/env-dev/data/outputs.tf
+++ b/infrastructure/env-dev/data/outputs.tf
@@ -1,0 +1,11 @@
+output "rds_address" {
+  value = "${module.data.rds_address}"
+}
+
+output "rds_endpoint" {
+  value = "${module.data.rds_endpoint}"
+}
+
+output "rds_sg_id" {
+  value = "${module.data.rds_sg_id}"
+}

--- a/infrastructure/env-dev/data/variables.tf
+++ b/infrastructure/env-dev/data/variables.tf
@@ -1,0 +1,4 @@
+variable "region" {
+  description = "AWS region where to deploy"
+  default     = "us-east-1"
+}

--- a/infrastructure/env-dev/network/outputs.tf
+++ b/infrastructure/env-dev/network/outputs.tf
@@ -6,6 +6,10 @@ output "back_subnets" {
   value = "${module.network.back_subnets}"
 }
 
+output "back_subnets_cidr" {
+  value = ["${module.network.back_subnets_cidr}"]
+}
+
 output "sg_internal_ssh_id" {
   value = "${module.network.sg_internal_ssh_id}"
 }

--- a/infrastructure/env-dev/web/main.tf
+++ b/infrastructure/env-dev/web/main.tf
@@ -9,6 +9,16 @@ data "terraform_remote_state" "network" {
   }
 }
 
+data "terraform_remote_state" "data" {
+  backend = "s3"
+
+  config {
+    bucket = "terraform-states-iac-experiment"
+    key    = "dev/data.tfstate"
+    region = "us-east-1"
+  }
+}
+
 data "aws_availability_zones" "all" {}
 
 provider "aws" {
@@ -50,6 +60,8 @@ module "back" {
   aws_availability_zones = ["${data.aws_availability_zones.all.names}"]
   sg_internal_ssh_id     = "${data.terraform_remote_state.network.sg_internal_ssh_id}"
   vpc_id                 = "${data.terraform_remote_state.network.vpc_id}"
+  rds_access             = true
+  sg_rds_id              = "${data.terraform_remote_state.data.sg_rds_id}"
 
   user_data = <<-EOF
               #!/bin/bash

--- a/infrastructure/modules/data/main.tf
+++ b/infrastructure/modules/data/main.tf
@@ -1,0 +1,34 @@
+resource "aws_db_instance" "main" {
+  allocated_storage      = "${var.allocated_storage}"
+  instance_class         = "${var.instance_class}"
+  engine                 = "mysql"
+  identifier             = "${var.env}-banana"
+  storage_type           = "gp2"
+  name                   = "${var.env}banana"
+  password               = "${var.db_password}"
+  username               = "root"
+  multi_az               = false
+  publicly_accessible    = false
+  db_subnet_group_name   = "${aws_db_subnet_group.back.id}"
+  vpc_security_group_ids = ["${aws_security_group.rds_sg.id}"]
+
+  tags {
+    Name      = "${var.env}-banana"
+    env       = "${var.env}"
+    infra     = "data"
+    terraform = true
+  }
+}
+
+resource "aws_db_subnet_group" "back" {
+  name        = "${var.env}-db-subnet"
+  description = "${var.env} - Banana DB to back"
+  subnet_ids  = ["${var.subnets_id}"]
+
+  tags {
+    Name      = "${var.env}-banana"
+    env       = "${var.env}"
+    infra     = "data"
+    terraform = true
+  }
+}

--- a/infrastructure/modules/data/outputs.tf
+++ b/infrastructure/modules/data/outputs.tf
@@ -1,0 +1,11 @@
+output "rds_address" {
+  value = "${aws_db_instance.main.address}"
+}
+
+output "rds_endpoint" {
+  value = "${aws_db_instance.main.endpoint}"
+}
+
+output "rds_sg_id" {
+  value = "${aws_security_group.rds_sg.id}"
+}

--- a/infrastructure/modules/data/outputs.tf
+++ b/infrastructure/modules/data/outputs.tf
@@ -6,6 +6,6 @@ output "rds_endpoint" {
   value = "${aws_db_instance.main.endpoint}"
 }
 
-output "rds_sg_id" {
+output "sg_rds_id" {
   value = "${aws_security_group.rds_sg.id}"
 }

--- a/infrastructure/modules/data/security_groups.tf
+++ b/infrastructure/modules/data/security_groups.tf
@@ -1,0 +1,20 @@
+resource "aws_security_group" "rds_sg" {
+  name        = "${var.env}-db"
+  description = "Allow connection from back subnets on 3306"
+
+  ingress {
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "TCP"
+    cidr_blocks = ["${var.cidr_blocks}"]
+  }
+
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name      = "${var.env}-data-sg"
+    env       = "${var.env}"
+    infra     = "data"
+    terraform = true
+  }
+}

--- a/infrastructure/modules/data/variables.tf
+++ b/infrastructure/modules/data/variables.tf
@@ -1,0 +1,33 @@
+variable "allocated_storage" {
+  default     = 5
+  description = "Allocated storage to the DB (5GB default)"
+}
+
+variable "instance_class" {
+  default     = "db.t2.micro"
+  description = "Instance hosting the DB (default db.t2.micro)"
+}
+
+variable "env" {
+  default     = "dev"
+  description = "prod/staging/DEV"
+}
+
+variable "db_password" {
+  default     = "Password01"  #TODO: change
+  description = "DB password"
+}
+
+variable "subnets_id" {
+  type        = "list"
+  description = "subnets ID in which to add the deployed instances"
+}
+
+variable "cidr_blocks" {
+  type        = "list"
+  description = "CIDR of subnet that can access the DB"
+}
+
+variable "vpc_id" {
+  description = "VPC id where to create the db sg"
+}

--- a/infrastructure/modules/network/outputs.tf
+++ b/infrastructure/modules/network/outputs.tf
@@ -6,6 +6,10 @@ output "back_subnets" {
   value = ["${aws_subnet.back.*.id}"]
 }
 
+output "back_subnets_cidr" {
+  value = ["${aws_subnet.back.*.cidr_block}"]
+}
+
 output "sg_internal_ssh_id" {
   value = "${aws_security_group.internal_ssh.id}"
 }

--- a/infrastructure/modules/web_infra/security_groups.tf
+++ b/infrastructure/modules/web_infra/security_groups.tf
@@ -31,6 +31,16 @@ resource "aws_security_group_rule" "instance_to_wan" {
   security_group_id = "${aws_security_group.instance.id}"
 }
 
+resource "aws_security_group_rule" "instance_to_db" {
+  count                    = "${var.rds_access}"
+  type                     = "egress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  source_security_group_id = "${var.sg_rds_id}"
+  security_group_id        = "${aws_security_group.instance.id}"
+}
+
 resource "aws_security_group" "main_elb" {
   name_prefix = "${var.env}-${var.infra}-ELB-"
   description = "${var.env}-${var.infra} - Allow communication from WAN to ELB (port ${var.elb_port}) and from ELB to instances (port ${var.elb_port})"

--- a/infrastructure/modules/web_infra/variables.tf
+++ b/infrastructure/modules/web_infra/variables.tf
@@ -63,3 +63,13 @@ variable "aws_availability_zones" {
   type        = "list"
   description = "List of available AZ in my region"
 }
+
+variable "rds_access" {
+  default     = false
+  description = "should this module implementation have access to the database"
+}
+
+variable "sg_rds_id" {
+  default     = ""
+  description = "Security group applied to the database to access"
+}


### PR DESCRIPTION
An RDS DB is now available on the infrastructure from the backend internal subnet only.
Minor changes have been made to the web module to allow backend EC2s to access the RDS endpoint.